### PR TITLE
Match optional space inside the GPU model number

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,8 @@ function compareStr(a, b) {
     }
     // b is now the longer array.
 
+    const unmatchedTokenWeight = 0.01;
+
     let matchedCount = 0;
     for (let ai = 0, al = a.length; ai < al; ai++) {
 
@@ -30,8 +32,8 @@ function compareStr(a, b) {
 
             } else if (bi > 0 && b[bi - 1] + b[bi] === a[ai] && b[bi - 1].length <= 3 && b[bi][0].match(/\d/)) {
 
-                // If the model number has a space in the middle, still treat it as a matching token.
-                matchedCount += 0.9;
+                // If the model number has a space in the middle, still treat it as a matching token - and lower the weight of the unmatched token.
+                matchedCount += 1 + unmatchedTokenWeight * 0.5;
                 break;
 
             }
@@ -39,7 +41,7 @@ function compareStr(a, b) {
     }
 
     const unmatchedTokens = a.length - matchedCount + b.length - matchedCount;
-    const score = matchedCount / Math.min(a.length, b.length) - unmatchedTokens * 0.001;
+    const score = matchedCount / Math.min(a.length, b.length) - unmatchedTokens * unmatchedTokenWeight;
 
     return score;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,13 +59,13 @@ function findMatch(name, list) {
 
         if (versionMatch[2] !== undefined) {
 
-            // "WX 3200" or "WX3200"
-            versionRegexp = new RegExp(`(^|\\W)${versionMatch[2]}\\W*${versionMatch[3]}(\\W|$)`, "i");
+            // Matched something like "WX 3200" or "WX3200"
+            versionRegexp = new RegExp(`(^|\\W)(${versionMatch[2]}\\W*)?${versionMatch[3]}(\\W|$)`, "i");
 
         } else {
 
-            // Just the digits.
-            versionRegexp = new RegExp(`(^|\\W)${versionMatch[3]}(\\W|$)`, "i");
+            // Matched just the digits.
+            versionRegexp = new RegExp(`(^|\\W|((^|\\W)[A-Z]{1,3}))${versionMatch[3]}(\\W|$)`, "i");
 
         }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,16 +9,37 @@ function compareStr(a, b) {
     if (typeof a === 'string') a = strToCompareArray(a);
     if (typeof b === 'string') b = strToCompareArray(b);
 
-    const matched = [];
-    for (let i = 0, l = a.length; i < l; i++) {
+    if (a.length > b.length) {
 
-        if (b.includes(a[i])) matched.push(a[i]);
+        const temp = a;
+        a = b;
+        b = temp;
 
     }
+    // b is now the longer array.
 
+    let matchedCount = 0;
+    for (let ai = 0, al = a.length; ai < al; ai++) {
 
-    const unmatchedTokens = a.length - matched.length + b.length - matched.length;
-    const score = (matched.length / Math.min(a.length, b.length)) - unmatchedTokens * 0.001;
+        for (let bi = 0, bl = b.length; bi < bl; bi++) {
+
+            if (b[bi] === a[ai]) {
+
+                ++matchedCount;
+                break;
+
+            } else if (bi > 0 && b[bi - 1] + b[bi] === a[ai] && b[bi - 1].length <= 3 && b[bi][0].match(/\d/)) {
+
+                // If the model number has a space in the middle, still treat it as a matching token.
+                matchedCount += 0.9;
+                break;
+
+            }
+        }
+    }
+
+    const unmatchedTokens = a.length - matchedCount + b.length - matchedCount;
+    const score = matchedCount / Math.min(a.length, b.length) - unmatchedTokens * 0.001;
 
     return score;
 
@@ -29,10 +50,25 @@ function findMatch(name, list) {
     let matches = null;
     let score = -Infinity;
 
-    const versionMatches = /\w*\d\d\d+\w*/.exec(name);
+    // We've seen samples of GPU names in both of these formats: "Radeon Pro WX 3200" and "Radeon Pro WX3200".
+    // We consider a version number as having an optional 1-3 letter uppercase prefix followed by at least 3 digits,
+    // and try to match them regardless of if there's a space between the uppercase prefix and the digits.
+    const versionMatch = /(^|\W)([A-Z]{1,3})?\W*(\d\d\d+\w*)/.exec(name);
     let versionRegexp = null;
-    if (versionMatches) {
-        versionRegexp = new RegExp(`(^|\\W)${ versionMatches[0] }(\\W|$)`, 'i');
+    if (versionMatch) {
+
+        if (versionMatch[2] !== undefined) {
+
+            // "WX 3200" or "WX3200"
+            versionRegexp = new RegExp(`(^|\\W)${versionMatch[2]}\\W*${versionMatch[3]}(\\W|$)`, "i");
+
+        } else {
+
+            // Just the digits.
+            versionRegexp = new RegExp(`(^|\\W)${versionMatch[3]}(\\W|$)`, "i");
+
+        }
+
     }
 
     const gpuArr = strToCompareArray(name);


### PR DESCRIPTION
We've seen samples of prefixed GPU model numbers given with both a space inside and no space inside. Examples:

Radeon Pro WX3200 vs.
Radeon Pro WX 3200

Change the name matching algorithm so that the version number may contain a short uppercase prefix and so that there's an optional space between the prefix and the digits.